### PR TITLE
Feature: Add github actions workflow to allow one-click deploy of docs site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build


### PR DESCRIPTION
This PR adds github actions to give us a deploy button in the repo so that we can deploy on demand. If you'd prefer, it's just as easy to set this up to auto-deploy on any change to `master` (PR, direct commit etc) but I went with the less automated option so that we can manually deploy from the repo as needed.